### PR TITLE
update clean view

### DIFF
--- a/src/main/java/org/polyfrost/overflowparticles/mixin/EntityLivingBaseMixin.java
+++ b/src/main/java/org/polyfrost/overflowparticles/mixin/EntityLivingBaseMixin.java
@@ -1,6 +1,5 @@
 package org.polyfrost.overflowparticles.mixin;
 
-import cc.polyfrost.oneconfig.libs.universal.UMinecraft;
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.Entity;
@@ -8,7 +7,6 @@ import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.world.World;
 import org.polyfrost.overflowparticles.OverflowParticles;
 import org.polyfrost.overflowparticles.config.BlockParticleEntry;
-import org.polyfrost.overflowparticles.config.MainConfig;
 import org.polyfrost.overflowparticles.config.ModConfig;
 import org.polyfrost.overflowparticles.config.ParticleConfig;
 import org.polyfrost.overflowparticles.utils.UtilKt;
@@ -20,15 +18,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class EntityLivingBaseMixin extends Entity {
     public EntityLivingBaseMixin(World worldIn) {
         super(worldIn);
-    }
-
-    @SuppressWarnings({"ConstantConditions"})
-    @Inject(method = "updatePotionEffects", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;spawnParticle(Lnet/minecraft/util/EnumParticleTypes;DDDDDD[I)V"), cancellable = true)
-    private void cleanView(CallbackInfo ci) {
-        if (worldObj != null && !worldObj.isRemote) return;
-        if (MainConfig.INSTANCE.getSettings().getCleanView() && (Object) this == UMinecraft.getPlayer()) {
-            ci.cancel();
-        }
     }
 
     @Redirect(method = "updateFallState", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;getMaterial()Lnet/minecraft/block/material/Material;"))

--- a/src/main/java/org/polyfrost/overflowparticles/mixin/particles/EntityParticleEmitterMixin.java
+++ b/src/main/java/org/polyfrost/overflowparticles/mixin/particles/EntityParticleEmitterMixin.java
@@ -1,8 +1,12 @@
 package org.polyfrost.overflowparticles.mixin.particles;
 
+import cc.polyfrost.oneconfig.libs.universal.UMinecraft;
+import net.minecraft.client.particle.EntityFX;
 import net.minecraft.client.particle.EntityParticleEmitter;
+import net.minecraft.entity.Entity;
 import net.minecraft.util.EnumParticleTypes;
 import org.polyfrost.overflowparticles.OverflowParticles;
+import org.polyfrost.overflowparticles.config.MainConfig;
 import org.polyfrost.overflowparticles.config.ParticleConfig;
 import org.polyfrost.overflowparticles.utils.UtilKt;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,9 +18,23 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(EntityParticleEmitter.class)
-public class EntityParticleEmitterMixin {
+public class EntityParticleEmitterMixin extends EntityFX {
+    @Shadow
+    private EnumParticleTypes particleTypes;
+    @Shadow
+    private Entity attachedEntity;
 
-    @Shadow private EnumParticleTypes particleTypes;
+    public EntityParticleEmitterMixin() {
+        super(null, 0, 0, 0, 0, 0, 0);
+    }
+
+    @Inject(method = "onUpdate", at = @At("HEAD"), cancellable = true)
+    public void cleanView(CallbackInfo ci) {
+        if (MainConfig.INSTANCE.getSettings().getCleanView() && this.attachedEntity == UMinecraft.getPlayer()) {
+            this.setDead();
+            ci.cancel();
+        }
+    }
 
     @ModifyConstant(method = "onUpdate", constant = @Constant(intValue = 16))
     private int multiplier(int constant) {

--- a/src/main/kotlin/org/polyfrost/overflowparticles/config/Settings.kt
+++ b/src/main/kotlin/org/polyfrost/overflowparticles/config/Settings.kt
@@ -16,7 +16,7 @@ class Settings {
 
     @Switch(
         name = "Clean View",
-        description = "Stop rendering your own potion effect particles.",
+        description = "Stop rendering your own particles.",
         subcategory = "Features"
     )
     var cleanView = false


### PR DESCRIPTION
## Description
updates the clean view to hide ALL particles the player makes, not just potion effects.
also makes it equivalent to badlion's clean view.

## How to test
<!-- Provide steps to test this PR -->
1. get attacked by a sharpness sword
2. notice how sharpness particles do not get emitted

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
Update "Clean View" to hide all player particles.
```