### PR TITLE
turn static particle color off by default (match vanilla)

### DIFF
--- a/src/main/kotlin/org/polyfrost/overflowparticles/client/config/OverflowParticlesConfig.kt
+++ b/src/main/kotlin/org/polyfrost/overflowparticles/client/config/OverflowParticlesConfig.kt
@@ -38,7 +38,7 @@ object OverflowParticlesConfig : Config("overflowparticles.json", "", "OverflowP
         subcategory = "Features"
     )
     @JvmStatic
-    var isStaticParticleColor = true
+    var isStaticParticleColor = false
 
     @Slider(
         title = "Max Particle Limit",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
this feature makes particles fullbright, which looks out of place when you dont use fullbright. maybe some people like that look but it shouldnt be defaul, and turning it off matches vanilla

particle core already caches brightness (https://github.com/fzzyhmstrs/pc/blob/master/src/main/java/me/fzzyhmstrs/particle_core/mixins/ParticleBrightnessCacheMixin.java) so there is barely any performance boost from this. it is mostly just an aesthetic change.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at docs.polyfrost.cc?
* Yes
  * 1. Please create a docs issue: https://github.com/Polyfrost/OneConfig-Documentation/issues/new
  * 2. Make sure this api is cross compatible with the existing api (or at least documented as such, see our policy on cross compatibility)
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->